### PR TITLE
SearchVC에서 검색 및 쿼리 작업(추가 작업 남음)

### DIFF
--- a/NewsResting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NewsResting.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/NewsResting.xcodeproj/xcuserdata/yeongjinjang.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/NewsResting.xcodeproj/xcuserdata/yeongjinjang.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>NewsResting.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>Rx (Playground) 1.xcscheme</key>
 		<dict>
@@ -42,6 +42,27 @@
 		</dict>
 		<key>Rx (Playground).xcscheme</key>
 		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+		<key>SnapKitPlayground (Playground) 1.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>2</integer>
+		</dict>
+		<key>SnapKitPlayground (Playground) 2.xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
+			<key>orderHint</key>
+			<integer>3</integer>
+		</dict>
+		<key>SnapKitPlayground (Playground).xcscheme</key>
+		<dict>
+			<key>isShown</key>
+			<false/>
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>

--- a/NewsResting.xcodeproj/xcuserdata/yeongjinjang.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/NewsResting.xcodeproj/xcuserdata/yeongjinjang.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>NewsResting.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>Rx (Playground) 1.xcscheme</key>
 		<dict>

--- a/NewsResting/Domain/UseCases/FetchRecentQueriesUseCase.swift
+++ b/NewsResting/Domain/UseCases/FetchRecentQueriesUseCase.swift
@@ -13,7 +13,7 @@ protocol FetchRecentQueriesUseCase {
 
 final class FetchRecentQueriesUseCaseImpl {
     private var queryRepository: NewsQueryRepository
-    private var maxCount = 5
+    private var maxCount = 10
     
     init(queryRepository: NewsQueryRepository) {
         self.queryRepository = queryRepository

--- a/NewsResting/Presentation/CategoriesNews/View/CategoriesViewController.swift
+++ b/NewsResting/Presentation/CategoriesNews/View/CategoriesViewController.swift
@@ -26,6 +26,7 @@ final class CategoriesViewController: UIViewController {
         setupAttributes()
         setupLayout()
         setupBinding()
+        setupNavigation()
         Task {
             try await viewModel.start()
             tableView.reloadData()
@@ -81,6 +82,19 @@ extension CategoriesViewController {
                 self.tableView.reloadData()
             }
         }
+    }
+    
+    @objc
+    func showSearchVC() {
+        self.navigationController?.pushViewController(SearchViewController(), animated: false)
+    }
+    
+    private func setupNavigation() {
+        navigationItem.setRightBarButton(UIBarButtonItem(barButtonSystemItem: .search,
+                                                         target: self,
+                                                         action: #selector(showSearchVC)),
+                                         animated: false)
+        
     }
 }
 

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -30,12 +30,12 @@ class QueryResultsViewController: UIViewController {
         super.viewDidLoad()
         setupLayout()
         setupAttribute()
-        view.backgroundColor = .systemGray
+        setupBinding()
     }
     
     private func setupLayout() {
         view.addSubview(tableView)
-        tableView.backgroundColor = .systemRed
+        
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -1,0 +1,29 @@
+//
+//  QueryResultsViewController.swift
+//  NewsResting
+//
+//  Created by YEONGJIN JANG on 2023/02/15.
+//
+
+import UIKit
+
+class QueryResultsViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -47,6 +47,8 @@ class QueryResultsViewController: UIViewController {
     private func setupAttribute() {
         tableView.register(QueryTableViewCell.self,
                            forCellReuseIdentifier: QueryTableViewCell.reusableIdentifier)
+        tableView.delegate = self
+        tableView.dataSource = self 
     }
     
     public func loadInitialQueries(_ text: String) {

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -45,7 +45,8 @@ class QueryResultsViewController: UIViewController {
     }
     
     private func setupAttribute() {
-        tableView.register(QueryTableViewCell.self, forCellReuseIdentifier: QueryTableViewCell.reusableIdentifier)
+        tableView.register(QueryTableViewCell.self,
+                           forCellReuseIdentifier: QueryTableViewCell.reusableIdentifier)
     }
     
     public func loadInitialQueries(_ text: String) {

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -73,8 +73,4 @@ extension QueryResultsViewController: UITableViewDelegate, UITableViewDataSource
         cell.fillUp(viewModel.query)
         return cell
     }
-    //TODO: - Need [Query: NewsListViewModel] Dictionary
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        <#code#>
-//    }
 }

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -51,17 +51,25 @@ class QueryResultsViewController: UIViewController {
         tableView.dataSource = self 
     }
     
+    private func setupBinding() {
+        recentQueriesViewModel.filterBind {
+            self.tableView.reloadData()
+        }
+    }
+    
+    public func filterQueries(_ text: String) {
+        recentQueriesViewModel.filterQuries(text)
     }
 }
 
 extension QueryResultsViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        recentQueriesViewModel.queries.count
+        recentQueriesViewModel.filteredQueries.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: QueryTableViewCell.reusableIdentifier, for: indexPath) as? QueryTableViewCell else { return UITableViewCell() }
-        let viewModel = recentQueriesViewModel.queries[indexPath.row]
+        let viewModel = recentQueriesViewModel.filteredQueries[indexPath.row]
         cell.fillUp(viewModel.query)
         return cell
     }

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -52,8 +52,10 @@ class QueryResultsViewController: UIViewController {
     }
     
     private func setupBinding() {
-        recentQueriesViewModel.filterBind {
-            self.tableView.reloadData()
+        recentQueriesViewModel.bindingFilter { [unowned self] in
+            Task {
+                self.tableView.reloadData()
+            }
         }
     }
     

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -7,23 +7,65 @@
 
 import UIKit
 
+
 class QueryResultsViewController: UIViewController {
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    private var recentQueriesViewModel: RecentQueriesViewModel
+    
+    private var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        return tableView
+    }()
+    
+    init(recentQueriesViewModel: RecentQueriesViewModel) {
+        self.recentQueriesViewModel = recentQueriesViewModel
+        super.init(nibName: nil, bundle: nil)
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-    */
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+        setupAttribute()
+        view.backgroundColor = .systemGray
+    }
+    
+    private func setupLayout() {
+        view.addSubview(tableView)
+        tableView.backgroundColor = .systemRed
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
+    
+    private func setupAttribute() {
+        tableView.register(QueryTableViewCell.self, forCellReuseIdentifier: QueryTableViewCell.reusableIdentifier)
+    }
+    
+    public func loadInitialQueries(_ text: String) {
+//        
+    }
+}
 
+extension QueryResultsViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        recentQueriesViewModel.queries.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: QueryTableViewCell.reusableIdentifier, for: indexPath) as? QueryTableViewCell else { return UITableViewCell() }
+        let viewModel = recentQueriesViewModel.queries[indexPath.row]
+        cell.fillUp(viewModel.query)
+        return cell
+    }
+    //TODO: - Need [Query: NewsListViewModel] Dictionary
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        <#code#>
+//    }
 }

--- a/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryResultsViewController.swift
@@ -51,8 +51,6 @@ class QueryResultsViewController: UIViewController {
         tableView.dataSource = self 
     }
     
-    public func loadInitialQueries(_ text: String) {
-//        
     }
 }
 

--- a/NewsResting/Presentation/SearchNews/View/QueryTableViewCell.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryTableViewCell.swift
@@ -8,16 +8,31 @@
 import UIKit
 
 class QueryTableViewCell: UITableViewCell {
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-        // Initialization code
+    private let queryLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .label
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
     }
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
-
+    
+    private func setupLayout() {
+        addSubview(queryLabel)
+        
+        queryLabel.snp.makeConstraints {
+            $0.top.bottom.leading.equalToSuperview()
+        }
+    }
+    
+    public func fillUp(_ query: String) {
+        self.queryLabel.text = query
+    }
 }
+

--- a/NewsResting/Presentation/SearchNews/View/QueryTableViewCell.swift
+++ b/NewsResting/Presentation/SearchNews/View/QueryTableViewCell.swift
@@ -1,0 +1,23 @@
+//
+//  QueryTableViewCell.swift
+//  NewsResting
+//
+//  Created by YEONGJIN JANG on 2023/02/15.
+//
+
+import UIKit
+
+class QueryTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -1,0 +1,15 @@
+//
+//  SearchViewController.swift
+//  NewsResting
+//
+//  Created by YEONGJIN JANG on 2023/02/15.
+//
+
+import UIKit
+
+class SearchViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -6,11 +6,95 @@
 //
 
 import UIKit
+import SnapKit
+
+
 
 class SearchViewController: UIViewController {
-
+    private var searchNewsViewModel = SearchNewsViewModel(usecase: SearchNewsUseCaseImpl(newsRepository: NewsRepositoryImpl(responseCache: CoreDataNewsResponseStorage())))
+    
+    private var recentQueriesViewModel = RecentQueriesViewModel(fetchRecentQueriesUseCase: FetchRecentQueriesUseCaseImpl(queryRepository: NewsQueryRepositoryImpl(newsQueryStorage: CoreDataNewsQueryStorage())))
+    
+    var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.register(QueryTableViewCell.self, forCellReuseIdentifier: QueryTableViewCell.reusableIdentifier)
+        return tableView
+    }()
+    
+    var searchController: UISearchController?
+    
+    //MARK: - View Contoller's life cycle
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .yellow
+        setupLayout()
+        setupAttribute()
+        setupNavigation()
+    }
+}
+
+//MARK: - Private
+extension SearchViewController {
+    private func setupLayout() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+    
+    private func setupAttribute() {
+        searchController = UISearchController(searchResultsController: QueryResultsViewController(recentQueriesViewModel: recentQueriesViewModel))
+        view.backgroundColor = .white
+        searchController?.searchResultsUpdater = self
+        searchController?.searchBar.delegate = self
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+    
+    private func setupNavigation() {
+        navigationItem.searchController = searchController
+        navigationItem.largeTitleDisplayMode = .always
+        navigationItem.title = "search term".localized()
+        navigationController?.navigationBar.prefersLargeTitles = true
+        
+        navigationItem.hidesSearchBarWhenScrolling = false
+    }
+}
+
+extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        recentQueriesViewModel.queries.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: QueryTableViewCell.reusableIdentifier, for: indexPath) as? QueryTableViewCell else { return UITableViewCell() }
+        let viewModel = recentQueriesViewModel.queries[indexPath.row]
+        cell.fillUp(viewModel.query)
+        return cell
+    }
+//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//        <#code#>
+//    }
+
+}
+
+//MARK: - Public
+extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let text = searchController.searchBar.text,
+              let resultVC = searchController.searchResultsController as? QueryResultsViewController
+        else { return }
+        resultVC.loadInitialQueries(text)
+        print(text)
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        guard let searchTerm = searchBar.text else { return }
+        Task {
+            let viewModel = try await searchNewsViewModel.getNews(searchTerm)
+            self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
+        }
     }
 }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -11,5 +11,6 @@ class SearchViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .yellow
     }
 }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -31,10 +31,19 @@ class SearchViewController: UIViewController {
         setupNavigation()
         setupBinding()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refrashSearchController()
+    }
 }
 
 //MARK: - Private
 extension SearchViewController {
+    private func refrashSearchController() {
+        searchController?.isActive = false
+    }
+    
     private func setupLayout() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(tableView)

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -88,7 +88,7 @@ extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text else { return }
         Task {
-            let viewModel = try await searchNewsViewModel.getNews(searchTerm)
+            let viewModel = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm)
             self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
         }
     }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -86,8 +86,7 @@ extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
         guard let text = searchController.searchBar.text,
               let resultVC = searchController.searchResultsController as? QueryResultsViewController
         else { return }
-        resultVC.loadInitialQueries(text)
-        print(text)
+        resultVC.filterQueries(text)
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -29,6 +29,7 @@ class SearchViewController: UIViewController {
         setupLayout()
         setupAttribute()
         setupNavigation()
+        setupBinding()
     }
 }
 
@@ -51,6 +52,14 @@ extension SearchViewController {
         searchController?.searchBar.delegate = self
         tableView.delegate = self
         tableView.dataSource = self
+    }
+    
+    private func setupBinding() {
+        recentQueriesViewModel.bindingQueries { [unowned self] in
+            Task {
+                self.tableView.reloadData()
+            }
+        }
     }
     
     private func setupNavigation() {
@@ -88,7 +97,8 @@ extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text else { return }
         Task {
-            let viewModel = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm)
+            let (query, viewModel) = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm)
+            recentQueriesViewModel.append(query: query, newsListViewModel: viewModel)
             self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
         }
     }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -74,10 +74,6 @@ extension SearchViewController: UITableViewDelegate, UITableViewDataSource {
         cell.fillUp(viewModel.query)
         return cell
     }
-//    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-//        <#code#>
-//    }
-
 }
 
 //MARK: - Public

--- a/NewsResting/Presentation/SearchNews/ViewModel/RecentQueriesViewModel.swift
+++ b/NewsResting/Presentation/SearchNews/ViewModel/RecentQueriesViewModel.swift
@@ -10,6 +10,8 @@ import Foundation
 final class RecentQueriesViewModel {
     private let fetchRecentQueriesUseCase: FetchRecentQueriesUseCase
     private(set) var queries: [NewsQuery] = []
+    private(set) var filteredQueries: [NewsQuery] = []
+    private var onFilterUpdated: () -> Void = { }
     
     init(fetchRecentQueriesUseCase: FetchRecentQueriesUseCase) {
         self.fetchRecentQueriesUseCase = fetchRecentQueriesUseCase
@@ -26,5 +28,16 @@ extension RecentQueriesViewModel {
         } catch {
             throw NetworkError.fetchQuriesFailure
         }
+    }
+    
+    func filterQuries(_ text: String)  {
+        filteredQueries = queries.filter {
+            $0.query.contains(text)
+        }
+        onFilterUpdated()
+    }
+    
+    func filterBind(completion: @escaping () -> Void) {
+        onFilterUpdated = completion
     }
 }

--- a/NewsResting/Presentation/SearchNews/ViewModel/RecentQueriesViewModel.swift
+++ b/NewsResting/Presentation/SearchNews/ViewModel/RecentQueriesViewModel.swift
@@ -9,8 +9,19 @@ import Foundation
 
 final class RecentQueriesViewModel {
     private let fetchRecentQueriesUseCase: FetchRecentQueriesUseCase
-    private(set) var queries: [NewsQuery] = []
-    private(set) var filteredQueries: [NewsQuery] = []
+    private(set) var queries: [NewsQuery] = [] {
+        didSet {
+            onQueriesUpdated()
+        }
+    }
+    private(set) var filteredQueries: [NewsQuery] = [] {
+        didSet {
+            onFilterUpdated()
+        }
+    }
+    
+    private var onQueriesUpdated: () -> Void = { }
+    
     private var onFilterUpdated: () -> Void = { }
     
     init(fetchRecentQueriesUseCase: FetchRecentQueriesUseCase) {
@@ -22,7 +33,7 @@ final class RecentQueriesViewModel {
 }
 
 extension RecentQueriesViewModel {
-    func fetchQuereis() async throws {
+    private func fetchQuereis() async throws {
         do {
             queries = try await fetchRecentQueriesUseCase.excute()
         } catch {
@@ -34,10 +45,19 @@ extension RecentQueriesViewModel {
         filteredQueries = queries.filter {
             $0.query.contains(text)
         }
-        onFilterUpdated()
     }
     
-    func filterBind(completion: @escaping () -> Void) {
+    func bindingFilter(completion: @escaping () -> Void) {
         onFilterUpdated = completion
+    }
+    
+    func bindingQueries(completion: @escaping () -> Void) {
+        onQueriesUpdated = completion
+    }
+    
+    func append(query: NewsQuery, newsListViewModel: NewsListViewModel) {
+        var reversedQueries = queries.reversed() as [NewsQuery]
+        reversedQueries.append(query)
+        queries = reversedQueries.reversed() as [NewsQuery]
     }
 }

--- a/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
+++ b/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
@@ -16,9 +16,9 @@ final class SearchNewsViewModel {
 }
 
 extension SearchNewsViewModel {
-    func fetchNewsListViewModel(_ searchWord: String) async throws -> NewsListViewModel {
+    func fetchNewsListViewModel(_ searchWord: String) async throws -> (NewsQuery, NewsListViewModel) {
         let newsQuery = NewsQuery(query: searchWord)
         let newsList = try await usecase.excute(query: newsQuery)
-        return NewsListViewModel(newsList: newsList)
+        return (newsQuery, NewsListViewModel(newsList: newsList))
     }
 }

--- a/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
+++ b/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
@@ -16,7 +16,7 @@ final class SearchNewsViewModel {
 }
 
 extension SearchNewsViewModel {
-    func getNews(_ searchWord: String) async throws -> NewsListViewModel {
+    func fetchNewsListViewModel(_ searchWord: String) async throws -> NewsListViewModel {
         let newsQuery = NewsQuery(query: searchWord)
         let newsList = try await usecase.excute(query: newsQuery)
         return NewsListViewModel(newsList: newsList)

--- a/NewsRestingTests/ViewModelTests/SearchNewsViewModelTest.swift
+++ b/NewsRestingTests/ViewModelTests/SearchNewsViewModelTest.swift
@@ -41,7 +41,7 @@ final class SearchNewsViewModelTest: XCTestCase {
     
     func testSearchWord() async throws {
         do {
-            let newsListViewModel = try await viewModel.getNews("korea")
+            let newsListViewModel = try await viewModel.fetchNewsListViewModel("korea")
             
             XCTAssertNoThrow(newsListViewModel)
             XCTAssertFalse(newsListViewModel.newsViewModel.isEmpty)
@@ -54,7 +54,7 @@ final class SearchNewsViewModelTest: XCTestCase {
         let words = ["color", "clock", "korea"]
         do {
             for str in words {
-                _ = try await viewModel.getNews(str)
+                _ = try await viewModel.fetchNewsListViewModel(str)
             }
             
             try await Task.sleep(nanoseconds: NSEC_PER_SEC * 1)


### PR DESCRIPTION
# 작업 내용
-  뉴스 검색 기능 UI
-  검색어에 따라 쿼리가 필터링 되는 기능 

# 추가 작업
- 검색어를 탭하면 해당 뉴스 리스트VC를 푸쉬
- 필터링 되는 쿼리를 전체 쿼리 풀에서 가져오기
  - 현재: 최근 10개 쿼리에서 검색어에 따라서 필터링됨 