### PR TITLE
[feature-#35] 스크롤이 바닥에 닿을 때 새로운 뉴스 불러오는 기능

### DIFF
--- a/NewsResting/Data/Network/CategoryResource.swift
+++ b/NewsResting/Data/Network/CategoryResource.swift
@@ -27,7 +27,8 @@ extension CategoryResource: APIResource {
     var query: [String : String] {
         [
             "country": CategoryResource.defaultCountry,
-            "category": newsCategoryDTO.category
+            "category": newsCategoryDTO.category,
+            "page": "\(newsCategoryDTO.page)"
         ]
     }
     

--- a/NewsResting/Data/Network/DataMapping/QueryDTO/NewsCategoryDTO+DataMapping.swift
+++ b/NewsResting/Data/Network/DataMapping/QueryDTO/NewsCategoryDTO+DataMapping.swift
@@ -10,12 +10,14 @@ import CoreData
 
 struct NewsCategoryDTO: Encodable {
     let category: String
+    let page: Int
 }
 
 extension NewsCategoryDTO: EntityConvertable {
     func toEntity(insertInto context: NSManagedObjectContext) -> NewsCategoryEntity {
         let entity = NewsCategoryEntity(context: context)
         entity.category = self.category
+        entity.page = Int64(self.page)
         return entity
     }
 }

--- a/NewsResting/Data/Network/DataMapping/QueryDTO/NewsQueryDTO+DataMapping.swift
+++ b/NewsResting/Data/Network/DataMapping/QueryDTO/NewsQueryDTO+DataMapping.swift
@@ -10,6 +10,7 @@ import CoreData
 
 struct NewsQueryDTO: Encodable {
     let query: String
+    let page: Int
 }
 
 extension NewsQueryDTO: EntityConvertable {

--- a/NewsResting/Data/Network/QueryResource.swift
+++ b/NewsResting/Data/Network/QueryResource.swift
@@ -25,7 +25,10 @@ extension QueryResource: APIResource {
 
     //TODO: - 키와 벨류 사이엔 "=", 키와 키 사이엔 "&"
     var query: [String : String] {
-        ["q": self.newsQueryRequestDTO.query]
+        [
+            "q": newsQueryRequestDTO.query,
+            "page": "\(newsQueryRequestDTO.page)"
+        ]
     }
 
     var header: [String : String] {

--- a/NewsResting/Data/PersistentStorage/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
+++ b/NewsResting/Data/PersistentStorage/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
@@ -25,6 +25,7 @@
     </entity>
     <entity name="NewsQueryEntity" representedClassName="NewsQueryEntity" syncable="YES" codeGenerationType="class">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="page" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="query" optional="YES" attributeType="String"/>
         <relationship name="response" maxCount="1" deletionRule="Cascade" destinationEntity="NewsListEntity" inverseName="request" inverseEntity="NewsListEntity"/>
     </entity>

--- a/NewsResting/Data/PersistentStorage/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
+++ b/NewsResting/Data/PersistentStorage/CoreDataStorage/CoreDataStorage.xcdatamodeld/CoreDataStorage.xcdatamodel/contents
@@ -2,6 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21512" systemVersion="21G83" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="NewsCategoryEntity" representedClassName="NewsCategoryEntity" syncable="YES" codeGenerationType="class">
         <attribute name="category" optional="YES" attributeType="String"/>
+        <attribute name="page" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="response" maxCount="1" deletionRule="Cascade" destinationEntity="NewsListEntity" inverseName="category" inverseEntity="NewsListEntity"/>
     </entity>
     <entity name="NewsEntity" representedClassName="NewsEntity" syncable="YES" codeGenerationType="class">

--- a/NewsResting/Data/PersistentStorage/NewsResponseStorage/CoreDataNewsResponseStorage.swift
+++ b/NewsResting/Data/PersistentStorage/NewsResponseStorage/CoreDataNewsResponseStorage.swift
@@ -146,8 +146,9 @@ extension CoreDataNewsResponseStorage {
     
     private func fetchRequest(categoryDTO: NewsCategoryDTO) -> NSFetchRequest<NewsCategoryEntity> {
         let request = NewsCategoryEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "%K = %@",
-                                        #keyPath(NewsCategoryEntity.category), categoryDTO.category
+        request.predicate = NSPredicate(format: "%K == %@ AND %K == %i" ,
+                                        #keyPath(NewsCategoryEntity.category), categoryDTO.category,
+                                        #keyPath(NewsCategoryEntity.page), categoryDTO.page
         )
         return request
     }

--- a/NewsResting/Data/Repositories/NewsRepositoryImpl.swift
+++ b/NewsResting/Data/Repositories/NewsRepositoryImpl.swift
@@ -37,8 +37,8 @@ extension NewsRepositoryImpl: NewsRepository {
     
     //TODO: - 두 펑션이 파라미터만 차이가 있지 사실상 하는일은 동일하여 중복되고 있음, 개선 방안이 있을까?
     //MARK: 쿼리를 이용해 뉴스 페치
-    func fetchNews(with query: NewsQuery) async throws -> NewsList {
-        let queryRequestDTO = NewsQueryDTO(query: query.query)
+    func fetchNews(with query: NewsQuery, page: Int) async throws -> NewsList {
+        let queryRequestDTO = NewsQueryDTO(query: query.query, page: page)
         
         if let cached = try? await responseCache.getSearchResponse(queryRequestDTO) {
             return cached

--- a/NewsResting/Data/Repositories/NewsRepositoryImpl.swift
+++ b/NewsResting/Data/Repositories/NewsRepositoryImpl.swift
@@ -20,8 +20,8 @@ final class NewsRepositoryImpl {
 //MARK: - Public
 extension NewsRepositoryImpl: NewsRepository {
     
-    func fetchNews(by category: NewsCategory) async throws -> NewsList {
-        let categoryRequestDTO = NewsCategoryDTO(category: category.text)
+    func fetchNews(by category: NewsCategory, page: Int) async throws -> NewsList {
+        let categoryRequestDTO = NewsCategoryDTO(category: category.text, page: page)
         
         if let cached = try? await responseCache.getCategoryResponse(categoryRequestDTO) {
             return cached

--- a/NewsResting/Domain/Interfaces/Repositories/NewsRepository.swift
+++ b/NewsResting/Domain/Interfaces/Repositories/NewsRepository.swift
@@ -9,5 +9,5 @@ import Foundation
 
 protocol NewsRepository {
     func fetchNews(with query: NewsQuery) async throws -> NewsList
-    func fetchNews(by category: NewsCategory) async throws -> NewsList
+    func fetchNews(by category: NewsCategory, page: Int) async throws -> NewsList
 }

--- a/NewsResting/Domain/Interfaces/Repositories/NewsRepository.swift
+++ b/NewsResting/Domain/Interfaces/Repositories/NewsRepository.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 protocol NewsRepository {
-    func fetchNews(with query: NewsQuery) async throws -> NewsList
+    func fetchNews(with query: NewsQuery, page: Int) async throws -> NewsList
     func fetchNews(by category: NewsCategory, page: Int) async throws -> NewsList
 }

--- a/NewsResting/Domain/UseCases/FetchCategoriesUesCase.swift
+++ b/NewsResting/Domain/UseCases/FetchCategoriesUesCase.swift
@@ -42,4 +42,8 @@ extension FetchCategoriesUseCaseImpl: FetchCategoriesUseCase {
             return allNewsList
         }
     }
+    
+    func getNextNews(_ category: NewsCategory, page: Int) async throws -> NewsList {
+        try await newsRepository.fetchNews(by: category, page: page)
+    }
 }

--- a/NewsResting/Domain/UseCases/FetchCategoriesUesCase.swift
+++ b/NewsResting/Domain/UseCases/FetchCategoriesUesCase.swift
@@ -9,6 +9,7 @@ import Foundation
 
 protocol FetchCategoriesUseCase {
     func excute() async throws -> [NewsCategory: NewsList]
+    func getNextNews(_ category: NewsCategory, page: Int) async throws -> NewsList
 }
 
 final class FetchCategoriesUseCaseImpl {
@@ -26,7 +27,7 @@ extension FetchCategoriesUseCaseImpl: FetchCategoriesUseCase {
             for category in NewsCategory.allCases {
                 taskGroup.addTask {
                     do {
-                        let newsList = try await self.newsRepository.fetchNews(by: category)
+                        let newsList = try await self.getNextNews(category, page: 1)
                         return (category, newsList)
                     } catch {
                         throw NetworkError.categoryFetchFailure(category)

--- a/NewsResting/Domain/UseCases/SearchNewsUseCase.swift
+++ b/NewsResting/Domain/UseCases/SearchNewsUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol SearchNewsUseCase {
-    func excute(query: NewsQuery) async throws -> NewsList
+    func excute(query: NewsQuery, page: Int) async throws -> NewsList
 }
 
 
@@ -21,9 +21,9 @@ final class SearchNewsUseCaseImpl {
 }
 
 extension SearchNewsUseCaseImpl: SearchNewsUseCase {
-    func excute(query: NewsQuery) async throws -> NewsList {
+    func excute(query: NewsQuery, page: Int) async throws -> NewsList {
         do {
-            let fetchedNewsList = try await newsRepository.fetchNews(with: query)
+            let fetchedNewsList = try await newsRepository.fetchNews(with: query, page: page)
             return fetchedNewsList
         } catch {
             throw NetworkError.searchFetchFailure(query)

--- a/NewsResting/Domain/UseCases/SearchNewsUseCase.swift
+++ b/NewsResting/Domain/UseCases/SearchNewsUseCase.swift
@@ -7,13 +7,6 @@
 
 import Foundation
 
-//TODO: - 이 값들을 NewsQuery에 포함시켜야할지에 대한 의문
-struct SearchNewsRequestValue {
-    let query: NewsQuery
-    //let sortBy: 1. 최신순, 2. 유명 언론 순
-    //let from - to
-}
-
 protocol SearchNewsUseCase {
     func excute(query: NewsQuery) async throws -> NewsList
 }

--- a/NewsResting/Presentation/CategoriesNews/View/CategoriesViewController.swift
+++ b/NewsResting/Presentation/CategoriesNews/View/CategoriesViewController.swift
@@ -123,6 +123,14 @@ extension CategoriesViewController: UITableViewDataSource, UITableViewDelegate {
         }
     }
     
+    //MARK: - When scroll reached to bottom
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if indexPath.row + 1 == viewModel.count {
+            Task {
+                try await viewModel.loadNextNews()
+            }
+        }
+    }
 }
 
 class CategoryViewItemCell: UITableViewCell {

--- a/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
+++ b/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
@@ -13,6 +13,7 @@ final class CategoriesViewModel {
     private var categories: [NewsCategory: NewsListViewModel] = [:]
     
     private(set) var currentSectionItems: NewsListViewModel?
+    private(set) var currentSection: NewsCategory?
     
     private var onSectionUpdated: () -> Void = { }
     
@@ -50,6 +51,9 @@ extension CategoriesViewModel {
     func setSection(category: NewsCategory) {
         guard let selectedNewsListViewModel = categories[category] else { return }
         currentSectionItems = selectedNewsListViewModel
+        currentSection = category
+        onSectionUpdated()
+    }
         onSectionUpdated()
     }
     

--- a/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
+++ b/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
@@ -14,6 +14,7 @@ final class CategoriesViewModel {
     
     private(set) var currentSectionItems: NewsListViewModel?
     private(set) var currentSection: NewsCategory?
+    private(set) var pageOfSection: [NewsCategory: Int] = [:]
     
     private var onSectionUpdated: () -> Void = { }
     
@@ -23,6 +24,9 @@ final class CategoriesViewModel {
     
     init(useCase: FetchCategoriesUseCase) {
         self.useCase = useCase
+        NewsCategory.allCases.forEach { cateogry in
+            pageOfSection[cateogry] = 1
+        }
         Task {
             try await start()
         }

--- a/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
+++ b/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
@@ -12,12 +12,12 @@ final class CategoriesViewModel {
     let useCase: FetchCategoriesUseCase
     private var categories: [NewsCategory: NewsListViewModel] = [:]
     
-    private(set) var currentSection: NewsListViewModel?
+    private(set) var currentSectionItems: NewsListViewModel?
     
     private var onSectionUpdated: () -> Void = { }
     
     var count: Int {
-        currentSection?.newsViewModel.count ?? 0
+        currentSectionItems?.newsViewModel.count ?? 0
     }
     
     init(useCase: FetchCategoriesUseCase) {
@@ -30,7 +30,7 @@ final class CategoriesViewModel {
 
 extension CategoriesViewModel {
     subscript(_ offset: Int) -> NewsItemViewModel? {
-        currentSection?.newsViewModel[offset]
+        currentSectionItems?.newsViewModel[offset]
     }
     
     func start() async throws {
@@ -49,7 +49,7 @@ extension CategoriesViewModel {
     //MARK: - Input
     func setSection(category: NewsCategory) {
         guard let selectedNewsListViewModel = categories[category] else { return }
-        currentSection = selectedNewsListViewModel
+        currentSectionItems = selectedNewsListViewModel
         onSectionUpdated()
     }
     

--- a/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
+++ b/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
@@ -58,11 +58,32 @@ extension CategoriesViewModel {
         currentSection = category
         onSectionUpdated()
     }
+    
+    func loadNextNews() async throws {
+        guard let category = currentSection,
+              let currentPage = pageOfSection[category]
+        else { return }
+            
+        let nextNewsList = try await useCase.getNextNews(category, page: currentPage + 1)
+        pageOfSection[category]? += 1
+        
+        append(nextNews: nextNewsList, at: category)
         onSectionUpdated()
     }
     
     //MARK: - Output
     func binding(completion: @escaping () -> Void) {
         onSectionUpdated = completion
+    }
+}
+
+
+//MARK: - Private
+extension CategoriesViewModel {
+    private func append(nextNews: NewsList, at category: NewsCategory) {
+        guard let existNewsListViewModel = categories[category] else { return }
+        let additionalNewsItemViewModels = nextNews.toViewModel().newsViewModel
+        let added = existNewsListViewModel.newsViewModel + additionalNewsItemViewModels
+        categories[category]?.newsViewModel = added
     }
 }

--- a/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
+++ b/NewsResting/Presentation/CategoriesNews/ViewModel/CategoriesViewModel.swift
@@ -19,7 +19,7 @@ final class CategoriesViewModel {
     private var onSectionUpdated: () -> Void = { }
     
     var count: Int {
-        currentSectionItems?.newsViewModel.count ?? 0
+        currentSectionItems?.count ?? 0
     }
     
     init(useCase: FetchCategoriesUseCase) {
@@ -83,7 +83,6 @@ extension CategoriesViewModel {
     private func append(nextNews: NewsList, at category: NewsCategory) {
         guard let existNewsListViewModel = categories[category] else { return }
         let additionalNewsItemViewModels = nextNews.toViewModel().newsViewModel
-        let added = existNewsListViewModel.newsViewModel + additionalNewsItemViewModels
-        categories[category]?.newsViewModel = added
+        existNewsListViewModel.append(newsItems: additionalNewsItemViewModels)
     }
 }

--- a/NewsResting/Presentation/NewsList/View/NewsListViewController.swift
+++ b/NewsResting/Presentation/NewsList/View/NewsListViewController.swift
@@ -59,7 +59,7 @@ extension NewsListViewController {
 
 extension NewsListViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        self.viewModel.newsViewModel.count
+        viewModel.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/NewsResting/Presentation/NewsList/ViewModel/NewsListViewModel.swift
+++ b/NewsResting/Presentation/NewsList/ViewModel/NewsListViewModel.swift
@@ -11,6 +11,10 @@ final class NewsListViewModel {
     private(set) var totalResults: Int
     var newsViewModel: [NewsItemViewModel] = []
 
+    var count: Int {
+        newsViewModel.count
+    }
+    
     init(newsList: NewsList) {
         self.totalResults = newsList.totalResults
         newsViewModel = newsList.articles.map { $0.toViewModel() }

--- a/NewsResting/Presentation/NewsList/ViewModel/NewsListViewModel.swift
+++ b/NewsResting/Presentation/NewsList/ViewModel/NewsListViewModel.swift
@@ -29,4 +29,8 @@ extension NewsListViewModel {
     var cellHeight: CGFloat {
         return 85
     }
+    
+    func append(newsItems: [NewsItemViewModel]) {
+        newsViewModel.append(contentsOf: newsItems)
+    }
 }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -118,9 +118,13 @@ extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let searchTerm = searchBar.text else { return }
         Task {
-            let (query, viewModel) = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm)
-            recentQueriesViewModel.append(query: query, newsListViewModel: viewModel)
-            self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
+            do {
+                let (query, viewModel) = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm, page: 1)
+                recentQueriesViewModel.append(query: query, newsListViewModel: viewModel)
+                self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
+            } catch {
+                debugPrint("Fetching \(searchTerm) News failed")
+            }
         }
     }
 }

--- a/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
+++ b/NewsResting/Presentation/SearchNews/View/SearchViewController.swift
@@ -121,7 +121,9 @@ extension SearchViewController: UISearchResultsUpdating, UISearchBarDelegate {
             do {
                 let (query, viewModel) = try await searchNewsViewModel.fetchNewsListViewModel(searchTerm, page: 1)
                 recentQueriesViewModel.append(query: query, newsListViewModel: viewModel)
-                self.navigationController?.pushViewController(NewsListViewController(newsListViewModel: viewModel), animated: true)
+                let vc = NewsListViewController(newsListViewModel: viewModel)
+                vc.title = query.query
+                self.navigationController?.pushViewController(vc, animated: true)
             } catch {
                 debugPrint("Fetching \(searchTerm) News failed")
             }

--- a/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
+++ b/NewsResting/Presentation/SearchNews/ViewModel/SearchNewsViewModel.swift
@@ -16,9 +16,9 @@ final class SearchNewsViewModel {
 }
 
 extension SearchNewsViewModel {
-    func fetchNewsListViewModel(_ searchWord: String) async throws -> (NewsQuery, NewsListViewModel) {
+    func fetchNewsListViewModel(_ searchWord: String, page: Int) async throws -> (NewsQuery, NewsListViewModel) {
         let newsQuery = NewsQuery(query: searchWord)
-        let newsList = try await usecase.excute(query: newsQuery)
+        let newsList = try await usecase.excute(query: newsQuery, page: page)
         return (newsQuery, NewsListViewModel(newsList: newsList))
     }
 }


### PR DESCRIPTION
# 관련 이슈 
#35 

# 작업 내용 
- [x] NewsCategoryDTO, NewsQueryDTO에 page 프로퍼티 추가
- [x] NewsQueryEntity, NewsCategoryEntity 에 page 프로퍼티 추가
- [x] CategoryResource, QueryResource에서 page에 대한 쿼리 파라미터 설정
- [x] 각종 NewsRepository, implements, UseCase 에서 page 파라미터 받도록 설정
- [x] NewsListViewModel에서 count computed property 추가, append(newsItems: [NewsItemViewModel]) 메서드 추가
- [x] 카테고리에서 다음 페이지 불러오는 것 확인
- [x] 검색에서 다음 페이지 불러오는 것 확인(API request 제한에 막혀서 못해봄, 내일 실시 예정)

## 버그 발견
- [ ] 기사 수가 적은 경우에 여러번 fetch를 page만 더하면서 진행하는 것을 발견
- [x] 검색어를 입력하고 바로 NewsListVC로 들어간 경우에는 맨아래 fetch 기능이 작동안함(캐싱된 쿼리에서 들어간 경우는 작동)
- [ ] 밑 바닥 도달 fetch 요청을 검색어 fetch로 인식해서 여러번 검색어가 쿼리됨
- [ ] `SearchViewController.searchBarSearchButtonClicked()` 하고 `NewsListViewController.tableview(willDisplay)` 가 하는 일이 비슷해보임, 이런 서로다른 뷰컨트롤러의 경우에 어떤식으로 뷰모델 액션을 이용해서 코드를 재사용할 수 있는지 검토

![image](https://user-images.githubusercontent.com/50472122/220495127-03a2ee00-86af-4f65-8080-0ac7b90f13bb.png)
